### PR TITLE
Enable recovery module by default

### DIFF
--- a/formula/libsecp256k1.rb
+++ b/formula/libsecp256k1.rb
@@ -2,8 +2,8 @@ class Libsecp256k1 < Formula
   desc "Optimized C library for EC operations on curve secp256k1"
   homepage "https://github.com/bitcoin/secp256k1"
   url "https://github.com/bitcoin/secp256k1.git",
-      :revision => "735fbde04e07df9d29719fadec4841b973d624d5"
-  version "2019.05.18.735fbd" # Fake version number to make updates easier.
+      :revision => "fa3301713549d118e57ebe6551d062903ddd6b63"
+  version "2019.06.12.fa3301" # Fake version number to make updates easier.
   head "https://github.com/bitcoin/secp256k1.git"
 
   depends_on "automake" => :build

--- a/formula/libsecp256k1.rb
+++ b/formula/libsecp256k1.rb
@@ -14,7 +14,7 @@ class Libsecp256k1 < Formula
 
   def install
     system "./autogen.sh"
-    system "./configure", "prefix=#{prefix}", "--disable-silent-rules"
+    system "./configure", "prefix=#{prefix}", "--disable-silent-rules", "--enable-module-recovery"
     system "make"
     system "./tests"
     system "make", "install"


### PR DESCRIPTION
Now that CKB has decided to [use recoverable signature](https://github.com/nervosnetwork/ckb-system-scripts/pull/15), we need to enable recovery module.