### PR TITLE
Remove doc about installing via raw formula URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,3 @@ Brew tap and install `<formula>`, example:
 brew tap nervosnetwork/tap
 brew install libsecp256k1
 ```
-
-You can also install via URL:
-
-```
-brew install https://raw.githubusercontent.com/nervosnetwork/homebrew-tap/master/formula/libsecp256k1.rb
-```


### PR DESCRIPTION
> Raw formula url install doesn’t work in newer versions of HomeBrew. Suggest eliminating that as an option in the README.
> via @ryanjames

Closes #5