### PR TITLE
Add cask for Tippy

### DIFF
--- a/Casks/tippy.rb
+++ b/Casks/tippy.rb
@@ -1,0 +1,11 @@
+cask "tippy" do
+    version "0.2.0"
+    sha256 "d509ef7fceaa5ecbe2db7d733bed207dd0f1409f95ae67dbe72f826e70a38db1"
+
+    url "https://github.com/nervosnetwork/tippy/releases/download/v#{version}/Tippy.dmg"
+    name "Tippy"
+    desc "One click CKB devnet"
+    homepage "https://github.com/nervosnetwork/tippy"
+
+    app "Tippy.app"
+  end

--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@ Brew tap and install `<formula>`, example:
 brew tap nervosnetwork/tap
 brew install libsecp256k1
 ```
+
+Or install by specifying `nervosnetwork/tap` directly, example:
+
+```
+brew install nervosnetwork/tap/tippy
+```


### PR DESCRIPTION
For user to install Tippy on macOS with `brew install nervosnetwork/tap/tippy`.